### PR TITLE
Upgrade to 0.12.0 and use `eslint/lib/config` to load config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.2.0 - 2015-01-23
+
+- Upgrade eslint to 0.12.0
+- Enable loading of eslint config from webpack config, `.eslintrc`, or `package.json`
+
 # 0.1.0 - 2014-12-05
 
 ✨

--- a/index.js
+++ b/index.js
@@ -1,8 +1,7 @@
 "use strict";
 
-var assign = require("object-assign")
 var eslint = require("eslint").linter
-var eslintConfig = require("eslint/conf/eslint.json")
+var Config = require("eslint/lib/config");
 // var loaderUtils = require("loader-utils")
 //
 /**
@@ -14,12 +13,6 @@ var eslintConfig = require("eslint/conf/eslint.json")
  */
 function lint(input, config, webpack) {
   var messages = []
-
-  // merge default config + user config
-  config = {
-    env: assign({}, eslintConfig.env, config.env),
-    rules: assign({}, eslintConfig.rules, config.rules)
-  }
 
   eslint.verify(input, config).forEach(function eslintMessageCallback(m) {
     messages.push(
@@ -45,61 +38,6 @@ function lint(input, config, webpack) {
 }
 
 /**
- * configuration loader
- *
- * @param {Object}   webpack
- * @param {Function} callback
- */
-function loadRcConfig(webpack, callback) {
-  var fs = require("fs")
-  var RcLoader = require("rcloader")
-  var rcLoader = new RcLoader(".eslintrc", null, {
-    loader: function(path) { return path }
-  })
-  var stripJsonComments = require("strip-json-comments")
-
-  if (typeof callback !== "function") {
-    var path = rcLoader.for(this.resourcePath)
-    if (typeof path !== "string") {
-      // no .rc found
-      return {}
-    }
-    else {
-      webpack.addDependency(path)
-      var file = fs.readFileSync(path, "utf8")
-      return JSON.parse(stripJsonComments(file))
-    }
-  }
-  else {
-    rcLoader.for(webpack.resourcePath, function rcLoaderCallback(err, path) {
-      if (err) {
-        throw err
-      }
-
-      if (typeof path !== "string") {
-        // no .rc found
-        return callback(null, {})
-      }
-
-      webpack.addDependency(path)
-      fs.readFile(path, "utf8", function loadRcConfigFileCallback(err, file) {
-        var options
-
-        if (!err) {
-          try {
-            options = JSON.parse(stripJsonComments(file))
-          }
-          catch (e) {
-            err = e
-          }
-        }
-        callback(err, options)
-      })
-    })
-  }
-}
-
-/**
  * webpack loader
  *
  * @param  {String|Buffer} input
@@ -109,27 +47,9 @@ module.exports = function(input) {
   this.options.eslint = this.options.eslint || {}
 
   this.cacheable()
-  var callback = this.async()
 
-    // sync
-  if (!callback) {
-    var config = loadRcConfig(this)
-    lint(input, config, this)
-    return input
-  }
-
-  // async
-  loadRcConfig(this, function loadRcConfigCallback(err, config) {
-    if (err) {
-      return callback(err)
-    }
-
-    try {
-      lint(input, config, this)
-    }
-    catch (e) {
-      return callback(e)
-    }
-    callback(null, input)
-  }.bind(this))
+  // sync
+  var config = new Config(this.options.eslint).getConfig()
+  lint(input, config, this)
+  return input
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-loader",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "eslint loader (for webpack)",
   "keywords": [
     "lint",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "index.js"
   ],
   "peerDependencies": {
-    "eslint": "^0.10.0"
+    "eslint": "^0.12.0"
   },
   "dependencies": {
     "loader-utils": "^0.2.5",
@@ -33,7 +33,7 @@
     "strip-json-comments": "^1.0.2"
   },
   "devDependencies": {
-    "eslint": "^0.10.0",
+    "eslint": "^0.12.0",
     "jscs": "^1.8.1",
     "tape": "^3.0.3",
     "webpack": "^1.4.13"


### PR DESCRIPTION
Upgrades to the current version of eslint.

Also, uses eslint's built-in ability to load configuration from `.eslintrc` and/or `package.json`.