### PR TITLE
Updating peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "index.js"
   ],
   "peerDependencies": {
-    "eslint": "^0.16.0"
+    "eslint": ">=0.16.0 <1.x"
   },
   "dependencies": {
     "object-assign": "^2.0.0"


### PR DESCRIPTION
This way people can use the eslint-loader with the newly release 0.17.0 version of eslint.