### PR TITLE
Upgrade eslint to 0.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,13 @@
-# 0.6.0 - 2015-02-11
+# 0.7.0 - 2015-03-15
+
+- Changed: upgrade to eslint 0.17.x
+
+# 0.6.0 - 2015-03-11
 
 - Changed: `reporter` now automatically drop lines that contains the filename in the reporter output.
-That mean you can use official or community reporters without worring to see lot of lines with `<text>` as filename :)
+That mean you can use official or community reporters without worrying to see lot of lines with `<text>` as filename :)
 
-# 0.5.0 - 2015-02-11
+# 0.5.0 - 2015-03-11
 
 - Changed: upgrade to eslint 0.16.x
 - Changed: `emitErrors` is now `emitError`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-loader",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "eslint loader (for webpack)",
   "keywords": [
     "lint",
@@ -24,13 +24,13 @@
     "index.js"
   ],
   "peerDependencies": {
-    "eslint": "^0.16.0"
+    "eslint": "^0.17.0"
   },
   "dependencies": {
     "object-assign": "^2.0.0"
   },
   "devDependencies": {
-    "eslint": "^0.16.0",
+    "eslint": "^0.17.0",
     "eslint-friendly-formatter": "^1.0.3",
     "tape": "^3.0.3",
     "webpack": "^1.4.13"


### PR DESCRIPTION
There seems to be another breaking change in how eslint supports react, so they released an upgraded version?

May be it's worth relaxing dependency requirements? If someone wants to ensure an incompatible version is not picked up, there is still a possibility to use shrinkwrap.