### PR TITLE
Make filepath available in reporters

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,6 @@ module.exports = {
 Loader accepts a function that will have one argument: an array of eslint messages (object).
 The function must return the output as a string.
 You can use official eslint reporters.
-**Please note that every lines with the filename will be skipped from output**
-because of the way the loader use eslint (just with a string of text, not a file - so no filename available)
 
 ```js
 module.exports = {

--- a/index.js
+++ b/index.js
@@ -29,13 +29,8 @@ function lint(input, config, webpack) {
   }
 
   if (res.errorCount || res.warningCount) {
+    res.results.forEach(function(r) { r.filePath = webpack.resourcePath; });
     var messages = webpack.options.eslint.reporter(res.results)
-    if (messages.indexOf(TEXT) > -1) {
-      messages = messages.split("\n").filter(function(line) {
-        // drop the line that should contains filepath we do not have
-        return !line.match(TEXT)
-      }).join("\n")
-    }
 
     // default behavior: emit error only if we have errors
     var emitter = res.errorCount ? webpack.emitError : webpack.emitWarning


### PR DESCRIPTION
I set the filepath to the resourcepath of webpack. So a custom reporter can use it to emit the filepath for each message.
For that to work I had to remove the special treatment of lines that contain the filename.
What do you think?
