### PR TITLE
Update dependencies. Relax eslint peer dependency to 0.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,17 +24,17 @@
     "index.js"
   ],
   "peerDependencies": {
-    "eslint": "^0.18.0"
+    "eslint": "0.x"
   },
   "dependencies": {
-    "loader-utils": "^0.2.6",
+    "loader-utils": "^0.2.7",
     "object-assign": "^2.0.0"
   },
   "devDependencies": {
-    "eslint": "^0.18.0",
-    "eslint-friendly-formatter": "^1.0.3",
-    "tape": "^3.0.3",
-    "webpack": "^1.4.13"
+    "eslint": "^0.19.0",
+    "eslint-friendly-formatter": "^1.0.5",
+    "tape": "^3.5.0",
+    "webpack": "^1.8.4"
   },
   "scripts": {
     "lint": "eslint .",


### PR DESCRIPTION

I needed to upgrade to eslint 0.19 but ran into this issue.

```
20:51 $ npm install eslint-loader
npm WARN peerDependencies The peer dependency eslint@^0.18.0 included from eslint-loader will no
npm WARN peerDependencies longer be automatically installed to fulfill the peerDependency 
npm WARN peerDependencies in npm 3+. Your application will need to depend on it explicitly.
npm ERR! Darwin 14.1.0
npm ERR! argv "/Users/nkbt/.nvm/versions/io.js/v1.6.2/bin/iojs" "/Users/nkbt/.nvm/versions/io.js/v1.6.2/bin/npm" "install" "eslint-loader"
npm ERR! node v1.6.2
npm ERR! npm  v2.7.1
npm ERR! code EPEERINVALID

npm ERR! peerinvalid The package eslint does not satisfy its siblings' peerDependencies requirements!
npm ERR! peerinvalid Peer eslint-loader@0.9.0 wants eslint@^0.18.0
```

So apparently semver thinks that 0.18 is not compatible with 0.19, and when `^0.18` is used in `peerDependencies` main project *must* use 0.18 exclusively. So this dependency was relaxed to `0.x`. After all, loader does not depend on eslint much so it should be ok and future-proof.

As soon as I updated this dependency, I decided to update other dependencies as well. Tests pass fine.

`npm install nkbt/eslint-loader#esloader-19` worked without any issues as well.


PS: I did not update eslint-loader own version, so if you merge this one, you will need to update it and publish to npm.