### PR TITLE
Now filename is passed to CLIEngine instance executeOnText method

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ var loaderUtils = require("loader-utils")
 function lint(input, config, webpack, callback) {
   var engine = new eslint.CLIEngine(config)
 
-  var resourcePath = webpack.resourcePath;
+  var resourcePath = webpack.resourcePath
   var cwd = process.cwd()
 
   // remove cwd from resource path in case webpack has been started from project

--- a/index.js
+++ b/index.js
@@ -14,7 +14,16 @@ var loaderUtils = require("loader-utils")
 function lint(input, config, webpack, callback) {
   var engine = new eslint.CLIEngine(config)
 
-  var res = engine.executeOnText(input)
+  var resourcePath = webpack.resourcePath;
+  var cwd = process.cwd()
+
+  // remove cwd from resource path in case webpack has been started from project
+  // root, to allow having relative paths in .eslintignore
+  if (resourcePath.indexOf(cwd) === 0) {
+    resourcePath = resourcePath.substr(cwd.length + 1)
+  }
+
+  var res = engine.executeOnText(input, resourcePath)
   // executeOnText ensure we will have res.results[0] only
 
   // quiet filter done now

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "object-assign": "^2.0.0"
   },
   "devDependencies": {
-    "eslint": "^0.19.0",
+    "eslint": "^0.21.2",
     "eslint-friendly-formatter": "^1.0.3",
     "tape": "^4.0.0",
     "webpack": "^1.8.4"

--- a/test/fixtures/ignore.js
+++ b/test/fixtures/ignore.js
@@ -1,0 +1,2 @@
+// this file should be totally ignore since it's present in .eslintignore
+var -dasdas;

--- a/test/index.js
+++ b/test/index.js
@@ -17,6 +17,12 @@ var conf = {
       },
     ],
   },
+  // this disables the use of .eslintignore, since it contains the fixture
+  // folder to skip for the global linting, but here we want the opposite
+  // (we only use .eslintignore to the test that checks this)
+  eslint: {
+    ignore: false,
+  },
 }
 
 test("eslint-loader don't throw error if file is ok", function(t) {
@@ -56,9 +62,9 @@ test("eslint-loader only returns errors and not warnings if quiet is set", funct
     conf,
     {
       entry: "./test/fixtures/warn.js",
-      eslint: {
+      eslint: assign({}, conf.eslint, {
         quiet: true,
-      },
+      }),
     }
   ),
   function(err, stats) {
@@ -90,9 +96,9 @@ test("eslint-loader can force to emit error", function(t) {
     conf,
     {
       entry: "./test/fixtures/warn.js",
-      eslint: {
+      eslint: assign({}, conf.eslint, {
         emitError: true,
-      },
+      }),
     }
   ),
   function(err, stats) {
@@ -109,9 +115,9 @@ test("eslint-loader can force to emit warning", function(t) {
     conf,
     {
       entry: "./test/fixtures/error.js",
-      eslint: {
+      eslint: assign({}, conf.eslint, {
         emitWarning: true,
-      },
+      }),
     }
   ),
   function(err, stats) {
@@ -145,9 +151,9 @@ test("eslint-loader can use custom formatter", function(t) {
     conf,
     {
       entry: "./test/fixtures/error.js",
-      eslint: {
+      eslint: assign(conf.eslint, {
         formatter: require("eslint-friendly-formatter"),
-      },
+      }),
     }
   ),
   function(err, stats) {
@@ -181,6 +187,26 @@ test("eslint-loader supports query strings parameters", function(t) {
 
     t.notOk(stats.hasErrors(), "a good file doesn't give any error")
     t.notOk(stats.hasWarnings(), "a good file doesn't give any warning")
+    t.end()
+  })
+})
+
+test("eslint-loader ignores files present in .eslintignore", function(t) {
+  webpack(assign({},
+    conf,
+    {
+      entry: "./test/fixtures/ignore.js",
+      eslint: assign({}, conf.eslint, {
+        // we want to enable ignore, so eslint will parse .eslintignore and
+        // should skip the file specified above
+        ignore: true,
+      }),
+    }
+  ),
+  function(err, stats) {
+    if (err) {throw err}
+
+    t.ok(stats.hasWarnings(), "an ignored file gives a warning")
     t.end()
   })
 })

--- a/test/index.js
+++ b/test/index.js
@@ -17,9 +17,9 @@ var conf = {
       },
     ],
   },
-  // this disables the use of .eslintignore, since it contains the fixture
-  // folder to skip for the global linting, but here we want the opposite
-  // (we only use .eslintignore to the test that checks this)
+  // this disables the use of .eslintignore, since it contains the fixtures
+  // folder to skip it on the global linting, but here we want the opposite
+  // (we only use .eslintignore on the test that checks this)
   eslint: {
     ignore: false,
   },

--- a/test/index.js
+++ b/test/index.js
@@ -151,7 +151,7 @@ test("eslint-loader can use custom formatter", function(t) {
     conf,
     {
       entry: "./test/fixtures/error.js",
-      eslint: assign(conf.eslint, {
+      eslint: assign({}, conf.eslint, {
         formatter: require("eslint-friendly-formatter"),
       }),
     }


### PR DESCRIPTION
Passing filename to executeOnText method gives eslint the possibility to ignore files which their paths are present in .eslintignore. I've also added the extraction of the cwd from context.resourcePath, since doing this allows having relative paths within .eslintignore as long as webpack is executed from the project root folder 