### PR TITLE
Update eslint-loader peerDep and bump version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-loader",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "eslint loader (for webpack)",
   "keywords": [
     "lint",
@@ -25,7 +25,7 @@
     "index.js"
   ],
   "peerDependencies": {
-    "eslint": "0.21 - 0.23"
+    "eslint": "0.21 - 0.24"
   },
   "dependencies": {
     "loader-utils": "^0.2.7",


### PR DESCRIPTION
Peer dependencies are going away in npm 3, should the peerDependency be removed?