### PR TITLE
Update ESLint peerDependency and add support for auto-fixing

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,6 +46,11 @@ function lint(input, config, webpack, callback) {
         })
     }
 
+    // if enabled, use eslint auto-fixing where possible
+    if (config.fix && res.results[0].output) {
+      eslint.CLIEngine.outputFixes(res)
+    }
+
     if (res.errorCount || res.warningCount) {
       // add filename for each results so formatter can have relevant filename
       res.results.forEach(function(r) {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "index.js"
   ],
   "peerDependencies": {
-    "eslint": "^1.0.0"
+    "eslint": "^1.6.0"
   },
   "dependencies": {
     "loader-utils": "^0.2.7",

--- a/test/autofix.js
+++ b/test/autofix.js
@@ -1,0 +1,49 @@
+var test = require("tape")
+var webpack = require("webpack")
+var assign = require("object-assign")
+var conf = require("./utils/conf")
+var fs = require("fs")
+
+// clone the "fixable" file, so that we do not lose the original contents
+// when the fixes are applied to disk 
+test("setup", function(t) {
+  fs
+    .createReadStream("./test/fixtures/fixable.js")
+    .pipe(fs.createWriteStream("./test/fixtures/fixable-clone.js"))
+
+  t.end()
+})
+
+test("loader doesn't throw error if file ok after auto-fixing", function(t) {
+  webpack(assign({},
+    conf,
+    {
+      entry: "./test/fixtures/fixable-clone.js",
+      module: {
+        loaders: [
+          {
+            test: /\.js$/,
+            loader: "./index?fix=true",
+            exclude: /node_modules/,
+          },
+        ],
+      },
+    }
+  ),
+  function(err, stats) {
+    if (err) {
+      throw err
+    }
+    // console.log(stats.compilation.errors)
+    t.notOk(stats.hasErrors(), "a good file doesn't give any error")
+    // console.log(stats.compilation.warnings)
+    t.notOk(stats.hasWarnings(), "a good file doesn't give any warning")
+    t.end()
+  })
+})
+
+// remove the clone
+test("teardown", function(t) {
+  fs.unlinkSync("./test/fixtures/fixable-clone.js")
+  t.end()
+})

--- a/test/fixtures/fixable.js
+++ b/test/fixtures/fixable.js
@@ -1,0 +1,7 @@
+'use strict';
+
+function foo() {
+return true;
+}  
+
+ foo();


### PR DESCRIPTION
Sorry I did not have chance to add tests for this yet, but I thought I may as well get the PR in as soon as possible so that others can benefit. It is working great for me so far as a webpack preLoader.

If "fix" is set to true, and there were fixable issues found, the result object from ESLint has an output property. This can easily be written back to disk using the static outputFixes() method on the CLIEngine.

As requested in: https://github.com/MoOx/eslint-loader/issues/64