### PR TITLE
pass down source map if it exists

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,10 +8,9 @@ var loaderUtils = require("loader-utils")
  * @param {String|Buffer} input JavaScript string
  * @param {Object} config eslint configuration
  * @param {Object} webpack webpack instance
- * @param {Function} callback optional callback for async loader
  * @return {void}
  */
-function lint(input, config, webpack, callback) {
+function lint(input, config, webpack) {
   var engine = new eslint.CLIEngine(config)
 
   var resourcePath = webpack.resourcePath
@@ -89,19 +88,16 @@ function lint(input, config, webpack, callback) {
       }
     }
   }
-
-  if (callback) {
-    callback(null, input)
-  }
 }
 
 /**
  * webpack loader
  *
  * @param  {String|Buffer} input JavaScript string
- * @returns {String|Buffer} original input
+ * @param {Object} map input source map
+ * @return {void}
  */
-module.exports = function(input) {
+module.exports = function(input, map) {
   var config = assign(
     // loader defaults
     {
@@ -113,21 +109,6 @@ module.exports = function(input) {
     loaderUtils.parseQuery(this.query)
   )
   this.cacheable()
-
-  var callback = this.async()
-  // sync
-  if (!callback) {
-    lint(input, config, this)
-
-    return input
-  }
-  // async
-  else {
-    try {
-      lint(input, config, this, callback)
-    }
-    catch (e) {
-      callback(e)
-    }
-  }
+  lint(input, config, this)
+  this.callback(null, input, map)
 }


### PR DESCRIPTION
This PR's primary purpose is passing down the input source map to the next chained loader if it exists. Although not a common use case, this is necessary if the code being linted was transformed by another loader before passed to `eslint-loader`. (In specific, with [vue-loader](https://github.com/vuejs/vue-loader) which extracts the JavaScript from a `*.vue` file then passes it through `eslint-loader`)

I also took the liberty to simplify the callback usage: since the `lint` function is in fact purely synchronous, there is no need to check for `this.async()` - simply using `this.callback()` will suffice.

### Regarding the failed test

When running the test locally, there is one autofix-related test failing **before this patch is applied**, likely due to ESLint updates since the last release. The post-patch test result is exactly the same, so the failed test should have nothing to do with this patch.