### PR TITLE
Fixing README notes on passing eslint options.

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ You can pass [eslint options](http://eslint.org/docs/user-guide/command-line-int
     preLoaders: [
       {
         test: /\.js$/,
-        loader: "eslint-loader?{rules:[{semi:0}]}",
+        loader: "eslint-loader?{rules:{semi:0}}",
         exclude: /node_modules/,
       },
     ],


### PR DESCRIPTION
The test suite appears to use the right format.