### PR TITLE
Bump object-assign to v4.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "loader-utils": "^0.2.7",
-    "object-assign": "^3.0.0"
+    "object-assign": "^4.0.1"
   },
   "devDependencies": {
     "eslint": "^1.6.0",


### PR DESCRIPTION
npm v3 tries to dedupe the dependencies by default, and keeping dependencies up-to-date helps better deduplication.

The breaking change is https://github.com/sindresorhus/object-assign/issues/22, but it doesn't affect the behavior of eslint-loader.
