### PR TITLE
Add caching ability to the loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,14 @@ This option will enable
 **Be careful, this option might cause webpack to enter an infinite build loop if
 some issues cannot be fixed properly.**
 
+#### `cache` (default: false)
+
+This option will enable caching of the linting results into a file.
+This is particullarly usefull to reduce linting time when doing full build.
+
+The cache is writting inside the `./node_modules/.cache` directory, thanks to the usage
+of the [find-cache-dir](https://www.npmjs.com/package/find-cache-dir) module.
+
 #### `formatter` (default: eslint stylish formatter)
 
 Loader accepts a function that will have one argument: an array of eslint messages (object).

--- a/index.js
+++ b/index.js
@@ -152,10 +152,7 @@ module.exports = function(input, map) {
       })
       cachePath = thunk("data.json")
       try {
-        var cacheFileContent = fs.readFileSync(cachePath)
-        if (cacheFileContent) {
-          cache = JSON.parse(cacheFileContent)
-        }
+        cache = require(cachePath)
       }
       catch (e) {
         cache = {}

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "eslint": ">=1.6.0 <4.0.0"
   },
   "dependencies": {
+    "find-cache-dir": "^0.1.1",
     "loader-utils": "^0.2.7",
     "object-assign": "^4.0.1"
   },


### PR DESCRIPTION
While webpack is great to pick up only incremental change, the compilation time at lunch can be very long. For our application, it takes minutes, which means it takes minutes before our tests can run, before we can deploy, before developer can start working when starting their day. 

I did similar changes to the coffee-loader, or the Uglify plugin, saving huge chunk of time.

Cache the eslint result into a file.
The input is hash using MD5 to detect changes.

```json
{
    "path.js": {
       "hash":"7c451761c8712467357cd5750e303d1f",
       "res": "what_ever"
}
```


This cut 30% of my webpack build time.

If this PR is accepted, I am happy to update the documentation and write a few tests.

Fixes https://github.com/MoOx/eslint-loader/issues/82

