### PR TITLE
add third parameter for  engine.executeOnText()

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ function lint(input, config, webpack) {
     resourcePath = resourcePath.substr(cwd.length + 1)
   }
 
-  var res = engine.executeOnText(input, resourcePath)
+  var res = engine.executeOnText(input, resourcePath, true)
   // executeOnText ensure we will have res.results[0] only
 
   // skip ignored file warning


### PR DESCRIPTION
relate to  eslint 3.0  change log:
https://github.com/eslint/eslint/blob/master/CHANGELOG.md

> 3b0ab0d Fix: add warnIgnored flag to CLIEngine.executeOnText (fixes #6302) (#6305) (Robert Levy)
