### PR TITLE
Fixed: additional config files no longer ignored

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ var crypto = require("crypto")
 var fs = require("fs")
 var findCacheDir = require("find-cache-dir")
 
-var engine = null
+var engine = {}
 var cache = null
 var cachePath = null
 
@@ -28,10 +28,11 @@ function lint(input, config, webpack) {
   }
 
   var res
+  var inputMD5
   // If cache is enable and the data are the same as in the cache, just
   // use them
   if (config.cache) {
-    var inputMD5 = crypto.createHash("md5").update(input).digest("hex")
+    inputMD5 = crypto.createHash("md5").update(input).digest("hex")
     if (cache[resourcePath] && cache[resourcePath].hash === inputMD5) {
       res = cache[resourcePath].res
     }
@@ -39,7 +40,7 @@ function lint(input, config, webpack) {
 
   // Re-lint the text if the cache off or miss
   if (!res) {
-    res = engine.executeOnText(input, resourcePath, true)
+    res = engine[config.configFile].executeOnText(input, resourcePath, true)
 
     // Save new results in the cache
     if (config.cache) {
@@ -137,9 +138,9 @@ module.exports = function(input, map) {
   )
   this.cacheable()
 
-  // Create the engine only once
-  if (engine === null) {
-    engine = new eslint.CLIEngine(config)
+  // Create an engine instance for every unique config file string specified
+  if (engine[config.configFile] === undefined) {
+    engine[config.configFile] = new eslint.CLIEngine(config)
   }
 
   // Read the cached information only once and if enable

--- a/test/configs.js
+++ b/test/configs.js
@@ -17,7 +17,10 @@ test("eslint-loader should respect custom configFile paths", function(t) {
         loaders: [
           {
             test: /\.js$/,
-            loader: "./index?{ configFile: './test/utils/eslint-config-quotes-single' }",
+            loader: "./index",
+            query: {
+              configFile: './test/utils/eslint-config-quotes-single',
+            },
             exclude: /node_modules/,
           },
         ],
@@ -56,12 +59,18 @@ test("eslint-loader should handle multiple configFile paths", function(t) {
         loaders: [
           {
             test: /\.js$/,
-            loader: "./index?{ configFile: './test/utils/eslint-config-quotes-single' }",
+            loader: "./index",
+            query: {
+              configFile: './test/utils/eslint-config-quotes-single',
+            },
             exclude: /node_modules/,
           },
           {
             test: /\.js$/,
-            loader: "./index?{ configFile: './test/utils/eslint-config-semi' }",
+            loader: "./index",
+            query: {
+              configFile: './test/utils/eslint-config-semi',
+            },
             exclude: /node_modules/,
           },
         ],

--- a/test/configs.js
+++ b/test/configs.js
@@ -19,7 +19,7 @@ test("eslint-loader should respect custom configFile paths", function(t) {
             test: /\.js$/,
             loader: "./index",
             query: {
-              configFile: './test/utils/eslint-config-quotes-single',
+              configFile: "./test/utils/eslint-config-quotes-single",
             },
             exclude: /node_modules/,
           },
@@ -61,7 +61,7 @@ test("eslint-loader should handle multiple configFile paths", function(t) {
             test: /\.js$/,
             loader: "./index",
             query: {
-              configFile: './test/utils/eslint-config-quotes-single',
+              configFile: "./test/utils/eslint-config-quotes-single",
             },
             exclude: /node_modules/,
           },
@@ -69,7 +69,7 @@ test("eslint-loader should handle multiple configFile paths", function(t) {
             test: /\.js$/,
             loader: "./index",
             query: {
-              configFile: './test/utils/eslint-config-semi',
+              configFile: "./test/utils/eslint-config-semi",
             },
             exclude: /node_modules/,
           },

--- a/test/configs.js
+++ b/test/configs.js
@@ -1,0 +1,87 @@
+var test = require("tape")
+var webpack = require("webpack")
+var assign = require("object-assign")
+var conf = require("./utils/conf")
+
+test("eslint-loader should respect custom configFile paths", function(t) {
+  webpack(assign({},
+    conf,
+    {
+      eslint: {
+        ignore: false,
+      },
+      entry: [
+        "./test/fixtures/good.js",
+      ],
+      module: {
+        loaders: [
+          {
+            test: /\.js$/,
+            loader: "./index?{ configFile: './test/utils/eslint-config-quotes-single' }",
+            exclude: /node_modules/,
+          },
+        ],
+      },
+    }
+  ),
+  function(err, stats) {
+    if (err) {
+      throw err
+    }
+
+    t.ok(
+      stats.compilation.warnings.length === 1,
+      "one warning for double quotes"
+    )
+
+    t.notOk(
+      stats.compilation.warnings.length !== 1,
+      "the config file was loaded and double quotes threw a warning"
+    )
+    t.end()
+  })
+})
+
+test("eslint-loader should handle multiple configFile paths", function(t) {
+  webpack(assign({},
+    conf,
+    {
+      eslint: {
+        ignore: false,
+      },
+      entry: [
+        "./test/fixtures/good.js",
+      ],
+      module: {
+        loaders: [
+          {
+            test: /\.js$/,
+            loader: "./index?{ configFile: './test/utils/eslint-config-quotes-single' }",
+            exclude: /node_modules/,
+          },
+          {
+            test: /\.js$/,
+            loader: "./index?{ configFile: './test/utils/eslint-config-semi' }",
+            exclude: /node_modules/,
+          },
+        ],
+      },
+    }
+  ),
+  function(err, stats) {
+    if (err) {
+      throw err
+    }
+
+    t.ok(
+      stats.compilation.warnings.length === 2,
+      "one warning from each config file"
+    )
+
+    t.notOk(
+      stats.compilation.warnings.length !== 2,
+      "all config files was loaded and each threw their warnings"
+    )
+    t.end()
+  })
+})

--- a/test/ok.js
+++ b/test/ok.js
@@ -3,7 +3,7 @@ var webpack = require("webpack")
 var assign = require("object-assign")
 var conf = require("./utils/conf")
 
-test("eslint-loader don't throw error if file is ok", function(t) {
+test("eslint-loader doesn't throw error if file is ok", function(t) {
   webpack(assign({},
     conf,
     {

--- a/test/utils/eslint-config-quotes-single
+++ b/test/utils/eslint-config-quotes-single
@@ -1,0 +1,11 @@
+---
+ecmaFeatures:
+  modules: true
+
+env:
+  es6: true
+  browser: true
+  node: true
+
+rules:
+  quotes: [1, "single"]

--- a/test/utils/eslint-config-semi
+++ b/test/utils/eslint-config-semi
@@ -1,0 +1,11 @@
+---
+ecmaFeatures:
+  modules: true
+
+env:
+  es6: true
+  browser: true
+  node: true
+
+rules:
+  semi: [1, "always"]


### PR DESCRIPTION
Resolves #105.

Per @MoOx's suggestions, I have scoped engine instances to every unique config file string, allowing for more than one engine instance. Multiple config files can now be used in a webpack config:

``` javascript
preLoaders: [
  {
    test: /\.js$/,
    loader: 'eslint-loader?{ configFile: "config-one.yaml" }'
  },
  {
    test: /\.spec\.js$/,
    loader: 'eslint-loader?{ configFile: "config-two.yaml" }'
  }
]
```

**Notes:**
- Moving the `inputMD5` declaration out of the inner `if` block was not necessary due to js hoisting, but since it is used outside the inner block it was visually being declared in I thought it made it more readable.
- I ran `npm run tape` locally and noticed there were some warnings that seemed unimportant and pre-existing prior to the changes in this commit.
