### PR TITLE
Option to generate report file

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ module.exports = {
 }
 ```
 
-[webpack@2.1.0-beta.23 has breaking changes](https://github.com/webpack/webpack/releases). 
+[webpack@2.1.0-beta.23 has breaking changes](https://github.com/webpack/webpack/releases).
 `preLoaders`  is removed  from the webpack^2.1.0-beta.23. so move it to `loaders` and using [enforce: "pre"]  instead.
 
 ```js
@@ -226,6 +226,27 @@ module.exports = {
 }
 ```
 
+##### `outputReport` (default: `false`)
+Write the output of the errors to a file
+
+You can pass in a different formatter for the output file, if none is passed in the default/configured formatter will be used
+
+```js
+module.exports = {
+  entry: "...",
+  module: {
+    // ...
+  },
+  eslint: {
+    outputReport: {
+      filename: 'checkstyle.xml',
+      formatter: require('eslint/lib/formatters/checkstyle')
+    }
+  }
+}
+```
+
+
 ## Gotchas
 
 ### NoErrorsPlugin
@@ -239,5 +260,3 @@ remove `NoErrorsPlugin` from webpack config.
 ## [Changelog](CHANGELOG.md)
 
 ## [License](LICENSE)
-
-

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ module.exports = {
 }
 ```
 
-[webpack@2.1.0-beta.23 has breaking changes](https://github.com/webpack/webpack/releases).
+[webpack@2.1.0-beta.23 has breaking changes](https://github.com/webpack/webpack/releases). 
 `preLoaders`  is removed  from the webpack^2.1.0-beta.23. so move it to `loaders` and using [enforce: "pre"]  instead.
 
 ```js

--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ module.exports = {
 ```
 
 ##### `outputReport` (default: `false`)
-Write the output of the errors to a file
+Write the output of the errors to a file, for example a checkstyle xml file for use for reporting on Jenkins CI
 
 The `filePath` is relative to the webpack config: output.path
 You can pass in a different formatter for the output file, if none is passed in the default/configured formatter will be used

--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ module.exports = {
 ##### `outputReport` (default: `false`)
 Write the output of the errors to a file
 
+The `filePath` is relative to the webpack config: output.path
 You can pass in a different formatter for the output file, if none is passed in the default/configured formatter will be used
 
 ```js
@@ -239,7 +240,7 @@ module.exports = {
   },
   eslint: {
     outputReport: {
-      filename: 'checkstyle.xml',
+      filePath: 'checkstyle.xml',
       formatter: require('eslint/lib/formatters/checkstyle')
     }
   }

--- a/index.js
+++ b/index.js
@@ -93,7 +93,7 @@ function lint(input, config, webpack) {
         else {
           reportOutput = messages
         }
-        webpack.emitFile(config.outputReport.filename, reportOutput)
+        webpack.emitFile(config.outputReport.filePath, reportOutput)
       }
 
       // default behavior: emit error only if we have errors

--- a/index.js
+++ b/index.js
@@ -84,6 +84,18 @@ function lint(input, config, webpack) {
       })
       var messages = config.formatter(res.results)
 
+      if (config.outputReport) {
+        var reportOutput
+        // if a different formatter is passed in as an option use that
+        if (config.outputReport.formatter) {
+          reportOutput = config.outputReport.formatter(res.results)
+        }
+        else {
+          reportOutput = messages
+        }
+        webpack.emitFile(config.outputReport.filename, reportOutput)
+      }
+
       // default behavior: emit error only if we have errors
       var emitter = res.errorCount ? webpack.emitError : webpack.emitWarning
 

--- a/test/formatter.js
+++ b/test/formatter.js
@@ -2,6 +2,7 @@ var test = require("tape")
 var webpack = require("webpack")
 var assign = require("object-assign")
 var conf = require("./utils/conf")
+var fs = require("fs")
 
 /* eslint-disable no-console */
 test("eslint-loader can use eslint formatter", function(t) {
@@ -54,6 +55,54 @@ test("eslint-loader can use custom formatter", function(t) {
       stats.compilation.errors[0].message,
       "webpack have some output with custom formatters"
     )
+    t.end()
+  })
+})
+
+test("eslint-loader cant be configured to write eslint results to a file",
+function(t) {
+
+  var outputFilename = "outputReport.txt"
+
+  webpack(assign({},
+    conf,
+    {
+      entry: "./test/fixtures/error.js",
+      eslint: assign({}, conf.eslint, {
+        formatter: require("eslint/lib/formatters/checkstyle"),
+        outputReport: {
+          filePath: outputFilename,
+        },
+      }),
+    }
+  ),
+  function(err, stats) {
+    if (err) {
+      throw err
+    }
+
+    console.log("### Here is a the outpur of the formatter")
+    console.log(
+      "# " +
+      stats.compilation.errors[0].message
+        .split("\n")
+        .join("\n# ")
+    )
+
+    fs.readFile(conf.output.path + outputFilename,
+      "utf8", function(err, contents) {
+        if (err) {
+          t.fail("Expected file to have been created")
+        }
+        else {
+          t.pass("File has been created")
+
+          t.equal(stats.compilation.errors[0].message, contents,
+            "File Contents should equal output")
+        }
+
+      })
+
     t.end()
   })
 })


### PR DESCRIPTION
This is about my second pull request ever so be gentle..

I have added the option to be able to write the ESLint output to a file, optionally using a different formatter, 
I am trying to use webpack on Jenkins CI and I needed to output a checkstyle xml file for reporting

https://github.com/MoOx/eslint-loader/issues/89