### PR TITLE
Changed: Removed test.only so that all tests will run

### DIFF
--- a/test/multiple-engines.js
+++ b/test/multiple-engines.js
@@ -3,7 +3,7 @@ var webpack = require("webpack")
 var assign = require("object-assign")
 var conf = require("./utils/conf")
 
-test.only("eslint-loader will create an engine for each unique config", function(t) { // eslint-disable-line max-len
+test("eslint-loader will create an engine for each unique config", function(t) { // eslint-disable-line max-len
   webpack(assign({},
     conf,
     {


### PR DESCRIPTION
The last merged PR #123 included a test file using test.only(). This PR changes it to a standard test() so all tests are run again.