### PR TITLE
Update Webpack 2 example

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,16 +59,20 @@ module.exports = {
 
 ```js
 module.exports = {
-  // ...
+  // entry, output, other top-level options ...
   module: {
-    loaders: [
-      {enforce: "pre", test: /\.js$/,  loader: "eslint-loader", exclude: /node_modules/}
-      // ... other loader
-    ]
-  }
-  // ...
-}
-```
+    rules: [
+      {
+        test: /\.js$/,
+        exclude: /node_modules/,
+        enforce: 'pre',
+        use: [{loader: 'eslint-loader', options: {rules: {semi: 0}}],
+      },
+      // other rules
+    ],
+  },
+  // no need for plugins
+};```
 
 ### Options
 

--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ module.exports = {
 }
 ```
 
-[webpack@2.1.0-beta.23 has breaking changes](https://github.com/webpack/webpack/releases).
-`preLoaders`  is removed  from the webpack^2.1.0-beta.23. so move it to `loaders` and using [enforce: "pre"]  instead.
+[webpack@2.2.0-rc.3 has breaking changes](https://github.com/webpack/webpack/releases).
+`preLoaders`  is removed  from the webpack^2.1.0-beta.23. so move it to `rules` and use `enforce: "pre"`  instead.
 
 ```js
 module.exports = {


### PR DESCRIPTION
The official Webpack 2 documentation no longer supports loaders or query, and using `enforce: pre` requires a separate rule (although you could just leave `eslint-loader` as the last rule, since they are applied in reverse order).

This PR updates the Webpack 2 example and fixes #113 