### PR TITLE
Fixed: ignore cache when eslint rules have changed

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ var findCacheDir = require("find-cache-dir")
 var objectHash = require("object-hash")
 
 var engines = {}
+var rules = {}
 var cache = null
 var cachePath = null
 
@@ -28,25 +29,39 @@ function lint(input, config, webpack) {
     resourcePath = resourcePath.substr(cwd.length + 1)
   }
 
+  // get engine
+  var configHash = objectHash(config)
+  var engine = engines[configHash]
+  var rulesHash = rules[configHash]
+
   var res
   // If cache is enable and the data are the same as in the cache, just
   // use them
   if (config.cache) {
+    // just get rules hash once per engine for performance reasons
+    if (!rulesHash) {
+      rulesHash = objectHash(engine.getConfigForFile(resourcePath))
+      rules[configHash] = rulesHash
+    }
     var inputMD5 = crypto.createHash("md5").update(input).digest("hex")
-    if (cache[resourcePath] && cache[resourcePath].hash === inputMD5) {
+    if (
+      cache[resourcePath] &&
+      cache[resourcePath].hash === inputMD5 &&
+      cache[resourcePath].rules === rulesHash
+    ) {
       res = cache[resourcePath].res
     }
   }
 
   // Re-lint the text if the cache off or miss
   if (!res) {
-    var configHash = objectHash(config)
-    res = engines[configHash].executeOnText(input, resourcePath, true)
+    res = engine.executeOnText(input, resourcePath, true)
 
     // Save new results in the cache
     if (config.cache) {
       cache[resourcePath] = {
         hash: inputMD5,
+        rules: rulesHash,
         res: res,
       }
       fs.writeFileSync(cachePath, JSON.stringify(cache))

--- a/test/cache.js
+++ b/test/cache.js
@@ -1,0 +1,56 @@
+var test = require("tape")
+var webpack = require("webpack")
+var assign = require("object-assign")
+var conf = require("./utils/conf")
+var fs = require("fs")
+
+var cacheFilePath = "./node_modules/.cache/eslint-loader/data.json"
+
+test("eslint-loader can cache results", function(t) {
+
+  // delete the require cache for eslint-loader otherwise any previously run
+  // tests will have initialised the cache as false and prevent this test
+  // from creating the cache file
+  delete require.cache[require.resolve("../index.js")]
+
+  webpack(assign({},
+    conf,
+    {
+      entry: "./test/fixtures/cache.js",
+      eslint: {
+        cache: true,
+      },
+    }
+  ),
+  function(err) {
+    if (err) {
+      throw err
+    }
+
+    fs.readFile(cacheFilePath, "utf8", function(err, contents) {
+      if (err) {
+        t.fail("expected cache file to have been created")
+      }
+      else {
+        t.pass("cache file has been created")
+
+        var contentsJson = JSON.parse(contents)
+        t.deepEqual(
+          Object.keys(contentsJson["test/fixtures/cache.js"]),
+          ["hash", "rules", "res"],
+          "cache values have been set for the linted file"
+        )
+      }
+
+      t.end()
+
+    })
+
+  })
+})
+
+// delete the cache file once tests have completed
+test("teardown", function(t) {
+  fs.unlinkSync(cacheFilePath)
+  t.end()
+})

--- a/test/cache.js
+++ b/test/cache.js
@@ -1,25 +1,18 @@
-var test = require("tape")
+var test = require("ava")
 var webpack = require("webpack")
-var assign = require("object-assign")
 var conf = require("./utils/conf")
 var fs = require("fs")
 
 var cacheFilePath = "./node_modules/.cache/eslint-loader/data.json"
 
-test("eslint-loader can cache results", function(t) {
-
-  // delete the require cache for eslint-loader otherwise any previously run
-  // tests will have initialised the cache as false and prevent this test
-  // from creating the cache file
-  delete require.cache[require.resolve("../index.js")]
-
-  webpack(assign({},
-    conf,
+test.cb("eslint-loader can cache results", function(t) {
+  t.plan(2)
+  webpack(conf(
     {
       entry: "./test/fixtures/cache.js",
-      eslint: {
-        cache: true,
-      },
+    },
+    {
+      cache: true,
     }
   ),
   function(err) {
@@ -50,7 +43,6 @@ test("eslint-loader can cache results", function(t) {
 })
 
 // delete the cache file once tests have completed
-test("teardown", function(t) {
+test.after.always("teardown", function() {
   fs.unlinkSync(cacheFilePath)
-  t.end()
 })

--- a/test/fixtures/cache.js
+++ b/test/fixtures/cache.js
@@ -1,0 +1,7 @@
+"use strict"
+
+function cacheIt() {
+  return "cache"
+}
+
+cacheIt()


### PR DESCRIPTION
I appear to have borked my previous branch after rebasing and it was easier to create a new one from master than figure out what I did wrong :)

This is a fix for #124 and the approach is as follows:
- Get a lint rules object for each CLIEngine instance (using [CLIEngine.getConfigForFile](http://eslint.org/docs/developer-guide/nodejs-api#getconfigforfile))
  - This is taken from the rules of the first file to be processed for each engine (I assume every file processed by the same engine will share the same lint rules)
- Hash the rules object
- Include the hashed rule in the cache against each file so it can also be compared when deciding whether to use the cache