### PR TITLE
Fallback to os temp directory if findCacheDir fail

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ var crypto = require("crypto")
 var fs = require("fs")
 var findCacheDir = require("find-cache-dir")
 var objectHash = require("object-hash")
+var os = require("os")
 
 var engines = {}
 var cache = null
@@ -165,7 +166,7 @@ module.exports = function(input, map) {
         thunk: true,
         create: true,
       })
-      cachePath = thunk("data.json")
+      cachePath = thunk("data.json") || os.tmpdir() + '/data.json';
       try {
         cache = require(cachePath)
       }

--- a/index.js
+++ b/index.js
@@ -166,7 +166,7 @@ module.exports = function(input, map) {
         thunk: true,
         create: true,
       })
-      cachePath = thunk("data.json") || os.tmpdir() + '/data.json'
+      cachePath = thunk("data.json") || os.tmpdir() + "/data.json"
       try {
         cache = require(cachePath)
       }

--- a/index.js
+++ b/index.js
@@ -166,7 +166,7 @@ module.exports = function(input, map) {
         thunk: true,
         create: true,
       })
-      cachePath = thunk("data.json") || os.tmpdir() + '/data.json';
+      cachePath = thunk("data.json") || os.tmpdir() + '/data.json'
       try {
         cache = require(cachePath)
       }


### PR DESCRIPTION
From the `find-cache-dir` readme: 

> Finds the cache dir using the supplied options. The algorithm tries to find a package.json file, searching every parent directory of the cwd specified (or implied from other options). It returns a string containing the absolute path to the cache directory, or null if package.json was never found.

 This is a fallback for null condition. Investigated after @gaearon comments on https://github.com/facebookincubator/create-react-app/pull/1578#discussion_r101802866