### PR TITLE
Upgrade to Webpack's loader-utils v1.0.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -147,7 +147,7 @@ module.exports = function(input, map) {
     // user defaults
     this.options.eslint || {},
     // loader query string
-    loaderUtils.parseQuery(this.query)
+    loaderUtils.getOptions(this)
   )
   this.cacheable()
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "find-cache-dir": "^0.1.1",
-    "loader-utils": "^0.2.7",
+    "loader-utils": "^1.0.2",
     "object-assign": "^4.0.1",
     "object-hash": "^1.1.4"
   },


### PR DESCRIPTION
Hi! I started getting this deprecation warning yesterday after updating to the latest version of Webpack:

```
(node:990) DeprecationWarning: loaderUtils.parseQuery() received a non-string value which can be problematic, see https://github.com/webpack/loader-utils/issues/56
parseQuery() will be replaced with getOptions() in the next major version of loader-utils.
    at Object.parseQuery (/Users/fknussel/workspace/x/node_modules/loader-utils/index.js:78:3)
    at Object.module.exports (/Users/fknussel/workspace/x/node_modules/eslint-loader/index.js:150:17)
    at LOADER_EXECUTION (/Users/fknussel/workspace/x/node_modules/loader-runner/lib/LoaderRunner.js:119:14)
    at runSyncOrAsync (/Users/fknussel/workspace/x/node_modules/loader-runner/lib/LoaderRunner.js:120:4)
    at iterateNormalLoaders (/Users/fknussel/workspace/x/node_modules/loader-runner/lib/LoaderRunner.js:229:2)
    at Array.<anonymous> (/Users/fknussel/workspace/x/node_modules/loader-runner/lib/LoaderRunner.js:202:4)
    at Storage.finished (/Users/fknussel/workspace/x/node_modules/enhanced-resolve/lib/CachedInputFileSystem.js:38:15)
    at /Users/fknussel/workspace/x/node_modules/enhanced-resolve/lib/CachedInputFileSystem.js:69:9
    at /Users/fknussel/workspace/x/node_modules/graceful-fs/graceful-fs.js:78:16
    at FSReqWrap.readFileAfterClose [as oncomplete] (fs.js:416:3)
```

I've set the `process.traceDeprecation` flag to `true` on my Webpack config file to find out which loader was causing the deprecation warning. As noted on the warning, this is related to [this other issue on webpack's loader-utils](https://github.com/webpack/loader-utils/issues/56).

This PR updates loader-utils to its latest version and therefore removes the deprecation warning.