### PR TITLE
Write 'webpack' in lower-case letters

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ module.exports = {
 
 ### NoErrorsPlugin
 
-`NoErrorsPlugin` prevents Webpack from outputting anything into a bundle. So even ESLint warnings
+`NoErrorsPlugin` prevents webpack from outputting anything into a bundle. So even ESLint warnings
 will fail the build. No matter what error settings are used for `eslint-loader`.
 
 So if you want to see ESLint warnings in console during development using `WebpackDevServer`


### PR DESCRIPTION
- "webpack should always be written in lower-case letters.
Even at the beginning of a sentence."
- https://github.com/webpack/media