### PR TITLE
Bugfix

### DIFF
--- a/index.js
+++ b/index.js
@@ -176,12 +176,17 @@ module.exports = function(input, map) {
   // Read the cached information only once and if enable
   if (cache === null) {
     if (config.cache) {
-      var thunk = findCacheDir({
-        name: "eslint-loader",
-        thunk: true,
-        create: true,
-      })
-      cachePath = thunk("data.json") || os.tmpdir() + "/data.json"
+      try {
+        var thunk = findCacheDir({
+          name: "eslint-loader",
+          thunk: true,
+          create: true,
+        })
+        cachePath = thunk("data.json") || os.tmpdir() + "/data.json"
+      }
+      catch (e) {
+        cachePath = os.tmpdir() + "/data.json"
+      }
       try {
         cache = require(cachePath)
       }


### PR DESCRIPTION
For certain set-ups the `find-cache-dir` module is not able to determine the cache directory and the `findCacheDir` function returns null instead of the expected thunk, resulting in an unhandled exception. This pull request fixes this problem and uses the default cache directory instead.