### PR TITLE
Bump the minimum required version for loader-fs-cache

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "find-cache-dir": "^0.1.1",
-    "loader-fs-cache": "^1.0.0",
+    "loader-fs-cache": "^1.0.1",
     "loader-utils": "^1.0.2",
     "object-assign": "^4.0.1",
     "object-hash": "^1.1.4",


### PR DESCRIPTION
1.0.0 naively uses mkdirp without listing it as dependency