### PR TITLE
Remove duplicate output.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+"use strict"
+
 var eslint = require("eslint")
 var assign = require("object-assign")
 var loaderUtils = require("loader-utils")
@@ -7,6 +9,33 @@ var createCache = require("loader-fs-cache")
 var cache = createCache("eslint-loader")
 
 var engines = {}
+
+/**
+ * Class representing an ESLintError.
+ * @extends Error
+ */
+class ESLintError extends Error {
+  /**
+   * Create an ESLintError.
+   * @param {string} messages - Formatted eslint errors.
+   */
+  constructor(messages) {
+    super()
+    this.name = "ESLintError"
+    this.message = messages
+    this.stack = ""
+  }
+
+  /**
+   * Returns a stringified representation of our error. This method is called
+   * when an error is consumed by console methods
+   * ex: console.error(new ESLintError(formattedMessage))
+   * @return {string} error - A stringified representation of the error.
+   */
+  inspect() {
+    return this.message
+  }
+}
 
 /**
  * printLinterOutput
@@ -80,17 +109,18 @@ function printLinterOutput(res, config, webpack) {
       }
 
       if (emitter) {
-        emitter(messages)
         if (config.failOnError && res.errorCount) {
-          throw new Error(
+          throw new ESLintError(
             "Module failed because of a eslint error.\n" + messages
           )
         }
         else if (config.failOnWarning && res.warningCount) {
-          throw new Error(
+          throw new ESLintError(
             "Module failed because of a eslint warning.\n" + messages
           )
         }
+
+        emitter(webpack.version === 2 ? new ESLintError(messages) : messages)
       }
       else {
         throw new Error(

--- a/test/formatter-write.js
+++ b/test/formatter-write.js
@@ -2,7 +2,6 @@
 var test = require("ava")
 var webpack = require("webpack")
 var conf = require("./utils/conf")
-var webpackWeirdPrefix = require("./utils/weird-prefix.js")
 var fs = require("fs")
 
 test.cb("eslint-loader can be configured to write eslint results to a file",
@@ -46,7 +45,7 @@ function(t) {
 
           t.is(
             stats.compilation.errors[0].message,
-            webpackWeirdPrefix + contents,
+            contents,
             "File Contents should equal output"
           )
         }

--- a/test/utils/weird-prefix.js
+++ b/test/utils/weird-prefix.js
@@ -1,7 +1,0 @@
-var webpackVersion = require("./version.js")
-
-module.exports = (
-  webpackVersion === "2"
-  ? "(Emitted value instead of an instance of Error) "
-  : ""
-)


### PR DESCRIPTION
Minimizes duplicate output in the following situations.

1. Duplicate ESLint messages are logged due to Webpack throwing `NonErrorEmittedError: (Emitted value instead of an instance of Error)`. This is done by emitting an new Error type ESLintError.

2. Duplicate ESLint messages caused by both emitting, and throwing an error. This was fixed fairly easy by moving the emit to below the throws.

Note: Because the formatted message acts as a stack trace, our ESLINTError sets the stack to the message. This keeps output clean when logged.

---

A few before and after screenshots:

**Build Before Patch**
![Build Before Patch](https://cldup.com/zL85uH9H2L.png)

**Build After Patch**
![Build After Patch](https://cldup.com/Xdn5xBU-gI.png)

**Start Before Patch**
![Start Before Patch](https://cldup.com/3OX-zntSPn.png)

**Start After Patch**
![Start After Patch](https://cldup.com/g_yDV1F3uu.png)

