### PR TITLE
Remove unused dependency find-cache-dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,8 +100,7 @@ some issues cannot be fixed properly.**
 This option will enable caching of the linting results into a file.
 This is particularly useful in reducing linting time when doing a full build.
 
-The cache file is written to the `./node_modules/.cache` directory, thanks to the usage
-of the [find-cache-dir](https://www.npmjs.com/package/find-cache-dir) module.
+The cache file is written to the `./node_modules/.cache` directory.
 
 #### `formatter` (default: eslint stylish formatter)
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "eslint": ">=1.6.0 <4.0.0"
   },
   "dependencies": {
-    "find-cache-dir": "^0.1.1",
     "loader-fs-cache": "^1.0.0",
     "loader-utils": "^1.0.2",
     "object-assign": "^4.0.1",


### PR DESCRIPTION
PR https://github.com/MoOx/eslint-loader/pull/159 replace the experimental implementation by something more robust.

So in order to keep things accurate, find-cache-dir should be removed.

The yarn.lock file did not change because find-cache-dir is used behind the scene by other modules.