### PR TITLE
Add eslint installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@
 $ npm install eslint-loader --save-dev
 ```
 
+**NOTE**: You also need to install `eslint` from npm, if you haven't already:
+
+```console
+$ npm install eslint --save-dev
+```
+
 ## Usage
 
 In your webpack configuration


### PR DESCRIPTION
I expected that `eslint-loader` has a dependency on eslint and that is would be installed automatically. After I've seen this error message:

![2017-07-13 16_41_42-cmd](https://user-images.githubusercontent.com/8310677/28172615-59a73924-67ec-11e7-8647-a71498a86c86.png)

and after digging into the code, I found out that it doesn't directly depend on it. This is an important information for a documentation.