### PR TITLE
Remove non-existent config option delete

### DIFF
--- a/index.js
+++ b/index.js
@@ -166,7 +166,6 @@ module.exports = function(input, map) {
   var cacheDirectory = config.cache
   var cacheIdentifier = config.cacheIdentifier
 
-  delete config.cacheDirectory
   delete config.cacheIdentifier
 
   // Create the engine only once per config


### PR DESCRIPTION
I could not find anything in the docs or tests to suggest that the config would have the option `cacheDirectory`. So removed the line `delete config.cacheDirectory`.